### PR TITLE
Fixes IndexError on save with removed member forwarding email

### DIFF
--- a/account/cbase_members.py
+++ b/account/cbase_members.py
@@ -18,6 +18,7 @@ CBASE_BASE_DN = 'ou=crew,dc=c-base,dc=org'
 def retrieve_member(request):
     ldap_password = get_ldap_password(request)
     session = dict(request.session)
+
     print("session:", session)
     print("cookies:", request.COOKIES)
     return MemberValues(request.user.username, ldap_password)
@@ -87,13 +88,13 @@ class MemberValues(object):
                 action = ldap.MOD_ADD
                 mod_attrs.append((action, '%s' % new_key, new_value))
                 continue
-            if self._old.get([new_key], [None])[0] is not None \
+            if self._old.get(new_key, [None])[0] is not None \
                     and new_value == [None]:
                 action = ldap.MOD_DELETE
                 mod_attrs.append((action, '%s' % new_key, []))
                 # Set the attribute and wait for the LDAP server to complete.
                 continue
-            if self._old.get([new_key], [None])[0] != new_value[0]:
+            if self._old.get(new_key, [None])[0] != new_value[0]:
                 action = ldap.MOD_REPLACE
                 mod_attrs.append((action, '%s' % new_key, new_value))
                 continue

--- a/account/cbase_members.py
+++ b/account/cbase_members.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import ldap
-import copy
-
-from django.conf import settings
-from account.password_encryption import get_ldap_password
-
 """
 Example configuration:
 
@@ -14,13 +8,30 @@ CBASE_LDAP_URL = 'ldap://lea.cbrp3.c-base.org:389/'
 CBASE_BASE_DN = 'ou=crew,dc=c-base,dc=org'
 """
 
+import copy
+import logging
+
+from django.conf import settings
+
+import ldap
+
+from account.password_encryption import get_ldap_password
+
+LOGGER = logging.getLogger(__name__)
+
 
 def retrieve_member(request):
+    """
+    Gets a MemberValues object by its user name bound to a request object.
+    :param request:
+    :return: A MemberValues object
+    """
     ldap_password = get_ldap_password(request)
-    session = dict(request.session)
+    request_session = dict(request.session)
 
-    print("session:", session)
-    print("cookies:", request.COOKIES)
+    LOGGER.info("session: %s", request_session)
+    LOGGER.info("cookies: %s", request.COOKIES)
+
     return MemberValues(request.user.username, ldap_password)
 
 
@@ -30,6 +41,13 @@ class MemberValues(object):
     """
 
     def __init__(self, username, password):
+        """
+        Initializes a MemberValues object with all necessary parameters to
+        synchronize with an LDAP server.
+
+        :param username:
+        :param password:
+        """
         self._username = username
         self._password = password
         self._old = self._get_user_values()
@@ -39,6 +57,12 @@ class MemberValues(object):
         self._new = copy.deepcopy(self._old)
 
     def get(self, key, default=None):
+        """
+        Gets a member attribute value by key.
+        :param key:
+        :param default:
+        :return:
+        """
         value_list = self._new.get(key, default)
         if value_list:
             value = value_list[0]
@@ -57,6 +81,12 @@ class MemberValues(object):
             return value
 
     def set(self, key, value):
+        """
+        Sets a member attribute value for a key replacing the old value
+        :param key:
+        :param value:
+        :return:
+        """
         if value is None:
             self._new[key] = [None]
             return
@@ -74,10 +104,10 @@ class MemberValues(object):
         """
         Save the values back to the LDAP server.
         """
-        dn = "uid=%s,ou=crew,dc=c-base,dc=org" % self._username
+        user_dn = "uid=%s,ou=crew,dc=c-base,dc=org" % self._username
 
-        l = ldap.initialize(settings.CBASE_LDAP_URL)
-        l.simple_bind_s(dn, self._password)
+        session = ldap.initialize(settings.CBASE_LDAP_URL)
+        session.simple_bind_s(user_dn, self._password)
 
         mod_attrs = []
         action = None
@@ -99,11 +129,10 @@ class MemberValues(object):
                 mod_attrs.append((action, '%s' % new_key, new_value))
                 continue
 
-        print("action: %s modattrs: %s", action, mod_attrs)
-        result = l.modify_s(dn, mod_attrs)
-        #
-        # print("result is: ", result)
-        l.unbind_s()
+        LOGGER.debug("action: %s modattrs: %s", action, mod_attrs)
+        result = session.modify_s(user_dn, mod_attrs)
+        LOGGER.debug("result is: %s", result)
+        session.unbind_s()
         return result  # does not harm any1
 
     def change_password(self, new_password):
@@ -111,15 +140,19 @@ class MemberValues(object):
         Change the password of the member.
         You do not need to call save() after calling change_password().
         """
-        l = ldap.initialize(settings.CBASE_LDAP_URL)
+        session = ldap.initialize(settings.CBASE_LDAP_URL)
         user_dn = self._get_bind_dn()
-        l.simple_bind_s(user_dn, self._password)
-        l.passwd_s(user_dn, self._password, new_password)
-        l.unbind_s()
+        session.simple_bind_s(user_dn, self._password)
+        session.passwd_s(user_dn, self._password, new_password)
+        session.unbind_s()
 
     def to_dict(self):
+        """
+        Converts a MembersValue object to a dict representation.
+        :return:
+        """
         result = {}
-        for key, value in self._new.items():
+        for key, _ in self._new.items():
             result[key] = self.get(key)
         return result
 
@@ -149,13 +182,16 @@ class MemberValues(object):
         retrieve_attributes = None
         search_filter = "uid=%s" % self._username
 
-        dn = settings.CBASE_BASE_DN
+        base_dn = settings.CBASE_BASE_DN
         result = session.search_s(
-            dn, search_scope, search_filter, retrieve_attributes
+            base_dn,
+            search_scope,
+            search_filter,
+            retrieve_attributes
         )
 
         # TODO: latin1
-        print("result is: ", result)
+        LOGGER.info("result is: %s", result)
         # TODO: if len(result)==0
         session.unbind_s()
         return result[0][1]
@@ -165,11 +201,11 @@ class MemberValues(object):
         Change the password of the member.
         You do not need to call save() after calling change_password().
         """
-        l = ldap.initialize(settings.CBASE_LDAP_URL)
+        session = ldap.initialize(settings.CBASE_LDAP_URL)
         user_dn = self._get_bind_dn()
-        l.simple_bind_s(user_dn, self._password)
-        l.passwd_s(self._get_bind_dn(username), None, new_password)
-        l.unbind_s()
+        session.simple_bind_s(user_dn, self._password)
+        session.passwd_s(self._get_bind_dn(username), None, new_password)
+        session.unbind_s()
 
     def get_number_of_members(self):
         """
@@ -182,11 +218,11 @@ class MemberValues(object):
         Returns a list of strings with all usernames in the group 'crew'.
         The list is sorted alphabetically.
         """
-        ldap_conn = ldap.initialize(settings.CBASE_LDAP_URL)
+        session = ldap.initialize(settings.CBASE_LDAP_URL)
         user_dn = self._get_bind_dn()
-        ldap_conn.simple_bind_s(user_dn, self._password)
+        session.simple_bind_s(user_dn, self._password)
         try:
-            result_id = ldap_conn.search(
+            result_id = session.search(
                 settings.CBASE_BASE_DN,
                 ldap.SCOPE_SUBTREE,
                 "memberOf=cn=crew,ou=groups,dc=c-base,dc=org",
@@ -194,7 +230,7 @@ class MemberValues(object):
             )
             result_set = []
             while True:
-                result_type, result_data = ldap_conn.result(result_id, 0)
+                result_type, result_data = session.result(result_id, 0)
                 if not result_data:
                     break
                 if result_type == ldap.RES_SEARCH_ENTRY:
@@ -212,4 +248,5 @@ class MemberValues(object):
             ) for x in result_set]
             return sorted(userlist)
         except Exception:
+            LOGGER.exception('list_users failed')
             return []

--- a/account/cbase_members.py
+++ b/account/cbase_members.py
@@ -79,6 +79,7 @@ class MemberValues(object):
         l.simple_bind_s(dn, self._password)
 
         mod_attrs = []
+        action = None
         for new_key, new_value in self._new.items():
             # Replace is the default.
             action = ldap.MOD_REPLACE
@@ -86,21 +87,23 @@ class MemberValues(object):
                 action = ldap.MOD_ADD
                 mod_attrs.append((action, '%s' % new_key, new_value))
                 continue
-            if self._old[new_key][0] != None and new_value == [None]:
+            if self._old.get([new_key], [None])[0] is not None \
+                    and new_value == [None]:
                 action = ldap.MOD_DELETE
                 mod_attrs.append((action, '%s' % new_key, []))
+                # Set the attribute and wait for the LDAP server to complete.
                 continue
-            # Set the attribute and wait for the LDAP server to complete.
-            if self._old[new_key][0] != new_value[0]:
+            if self._old.get([new_key], [None])[0] != new_value[0]:
                 action = ldap.MOD_REPLACE
                 mod_attrs.append((action, '%s' % new_key, new_value))
                 continue
 
-        print("modattrs: ", mod_attrs)
+        print("action: %s modattrs: %s", action, mod_attrs)
         result = l.modify_s(dn, mod_attrs)
         #
         # print("result is: ", result)
         l.unbind_s()
+        return result  # does not harm any1
 
     def change_password(self, new_password):
         """

--- a/account/forms.py
+++ b/account/forms.py
@@ -7,33 +7,41 @@ from django import forms
 from django.contrib.auth import authenticate
 from django.utils.translation import ugettext as _
 
+
 class UsernameField(forms.CharField):
     """
-    The username field makes sure that usernames are always entered in lower-case.
-    If we do not convert the username to lower-case, Django will create more than
-    one user object in the database. If we then try to login again, the Django auth
-    subsystem will do an query that looks like this: username__iexact="username". The
-    result is an error, because iexact returns the objects for "username" and "Username".
+    The username field makes sure that usernames are always entered in
+    lower-case. If we do not convert the username to lower-case, Django will
+    create more than one user object in the database. If we then try to login
+    again, the Django auth subsystem will do an query that looks like this:
+    username__iexact="username". The result is an error, because iexact returns
+    the objects for "username" and "Username".
     """
-    
+
     def to_python(self, value):
         value = super(UsernameField, self).to_python(value)
         value = value.lower()
         return value
-    
+
 
 class LoginForm(forms.Form):
     username = UsernameField(max_length=255)
-    password = forms.CharField(max_length=255, widget=forms.PasswordInput,
+    password = forms.CharField(
+        max_length=255, widget=forms.PasswordInput,
         help_text=_('Cookies must be enabled.'))
-        
+
     def clean(self):
         username = self.cleaned_data.get('username')
         password = self.cleaned_data.get('password')
         user = authenticate(username=username, password=password)
         if not user or not user.is_active:
-            raise forms.ValidationError(_('Sorry, that login was invalid. '
-                                          'Please try again.'), code='invalid_login')
+            raise forms.ValidationError(
+                _(
+                    'Sorry, that login was invalid. '
+                    'Please try again.'
+                ),
+                code='invalid_login'
+            )
         return self.cleaned_data
 
     def login(self, request):
@@ -45,6 +53,7 @@ class LoginForm(forms.Form):
 
 class GastroPinField(forms.CharField):
     widget = forms.PasswordInput
+
     def validate(self, value):
         """
         Check if the value is all numeric and 4 - 8 chars long.
@@ -56,7 +65,8 @@ class GastroPinField(forms.CharField):
 
 class GastroPinForm(forms.Form):
     gastropin1 = GastroPinField(label=_('New Gastro-PIN'))
-    gastropin2 = GastroPinField(label=_('Repeat Gastro-PIN'),
+    gastropin2 = GastroPinField(
+        label=_('Repeat Gastro-PIN'),
         help_text=_('Numerical only, 4 to 8 digits'))
 
     def clean(self):
@@ -67,24 +77,33 @@ class GastroPinForm(forms.Form):
         if gastropin1 != gastropin2:
             raise forms.ValidationError(
                 _('The PINs entered were not identical.'),
-                code='not_identical')
+                code='not_identical'
+            )
         return cleaned_data
 
 
 class WlanPresenceForm(forms.Form):
     # Boolean fields must never be required.
-    presence = forms.BooleanField(required=False,
-            label=_('Enable WiFi presence'))
+    presence = forms.BooleanField(
+        required=False,
+        label=_('Enable WiFi presence')
+    )
 
 
 class PasswordForm(forms.Form):
-    old_password = forms.CharField(max_length=255, widget=forms.PasswordInput,
+    old_password = forms.CharField(
+        max_length=255, widget=forms.PasswordInput,
         label=_('Old password'),
-        help_text=_('Enter your current password here.'))
-    password1 = forms.CharField(max_length=255, widget=forms.PasswordInput,
-        label=_('New password'))
-    password2 = forms.CharField(max_length=255, widget=forms.PasswordInput,
-        label=_('Repeat password'))
+        help_text=_(
+            'Enter your current password here.'))
+    password1 = forms.CharField(
+        max_length=255, widget=forms.PasswordInput,
+        label=_('New password')
+    )
+    password2 = forms.CharField(
+        max_length=255, widget=forms.PasswordInput,
+        label=_('Repeat password')
+    )
 
     def __init__(self, *args, **kwargs):
         self._request = kwargs.pop('request', None)
@@ -97,8 +116,12 @@ class PasswordForm(forms.Form):
         user = authenticate(username=username, password=old_password)
 
         if not user or not user.is_active:
-            raise forms.ValidationError(_('The old password was incorrect.'),
-                    code='old_password_wrong')
+            raise forms.ValidationError(
+                _(
+                    'The old password was incorrect.'
+                ),
+                code='old_password_wrong'
+            )
 
         password1 = cleaned_data.get('password1')
         password2 = cleaned_data.get('password2')
@@ -115,9 +138,14 @@ class PasswordForm(forms.Form):
 
 
 class RFIDForm(forms.Form):
-    rfid = forms.CharField(max_length=255, label=_('Your RFID'),
-        help_text=_('Find out your RFID by holding your RFID tag to the '
-                    'reader in the airlock.'))
+    rfid = forms.CharField(
+        max_length=255,
+        label=_('Your RFID'),
+        help_text=_(
+            'Find out your RFID by holding your RFID tag to the '
+            'reader in the airlock.'
+        )
+    )
 
 
 class SIPPinForm(forms.Form):
@@ -135,30 +163,44 @@ class SIPPinForm(forms.Form):
 
 
 class NRF24Form(forms.Form):
-    nrf24 = forms.CharField(max_length=255,
-        label = _('NRF24-ID'),
-        help_text=_("Your r0ket's NRF24 identification"))
+    nrf24 = forms.CharField(
+        max_length=255,
+        label=_('NRF24-ID'),
+        help_text=_("Your r0ket's NRF24 identification")
+    )
 
 
 class CLabPinForm(forms.Form):
     c_lab_pin1 = GastroPinField(label=_('New indoor PIN'))
-    c_lab_pin2 = GastroPinField(label=_('Repeat indoor PIN'),
-            help_text=_('Numerical only, 4 to 8 digits'))
+    c_lab_pin2 = GastroPinField(
+        label=_('Repeat indoor PIN'),
+        help_text=_('Numerical only, 4 to 8 digits')
+    )
 
 
 class PreferredEmailForm(forms.Form):
-    preferred_email = forms.EmailField(max_length=255, required=False,
-        label = _('Preferred e-mail'),
-        help_text=_("Forward my mail to this address. Leave empty to use the c-base IMAP and SMTP servers."))
+    preferred_email = forms.EmailField(
+        max_length=255, required=False,
+        label=_('Preferred e-mail'),
+        help_text=_(
+            "Forward my mail to this address. Leave empty to use the c-base "
+            "IMAP and SMTP servers."
+        )
+    )
 
 
 class AdminForm(forms.Form):
     username = forms.ChoiceField(choices=[])
-    password1 = forms.CharField(max_length=255, widget=forms.PasswordInput,
-        label=_('New password'))
-    password2 = forms.CharField(max_length=255, widget=forms.PasswordInput,
-        label=_('Repeat password'))
-
+    password1 = forms.CharField(
+        max_length=255,
+        widget=forms.PasswordInput,
+        label=_('New password')
+    )
+    password2 = forms.CharField(
+        max_length=255,
+        widget=forms.PasswordInput,
+        label=_('Repeat password')
+    )
 
     def __init__(self, *args, **kwargs):
         self._request = kwargs.pop('request', None)
@@ -166,10 +208,23 @@ class AdminForm(forms.Form):
         choices = [x for x in self._users]
         choices.insert(0, ('', 'Select username ...'))
         super(AdminForm, self).__init__(*args, **kwargs)
-        #self.fields.insert(0, 'username', forms.ChoiceField(choices=choices,
-            #help_text=_('Select the username for whom you want to reset the password.')))
-        self.fields['username'] =  forms.ChoiceField(choices=choices,
-            help_text=_('Select the username for whom you want to reset the password.'))
+        # self.fields.insert(
+        #     0,
+        #     'username',
+        #     forms.ChoiceField(
+        #         choices=choices,
+        #         help_text=_(
+        #             'Select the username for whom you want '
+        #             'to reset the password.'
+        #         )
+        #     )
+        # )
+        self.fields['username'] = forms.ChoiceField(
+            choices=choices,
+            help_text=_(
+                'Select the username for whom you want to reset the password.'
+            )
+        )
 
     def clean(self):
         cleaned_data = super(AdminForm, self).clean()
@@ -179,11 +234,13 @@ class AdminForm(forms.Form):
         if password1 != password2:
             raise forms.ValidationError(
                 _('The new passwords were not identical.'),
-                code='not_identical')
+                code='not_identical'
+            )
         if len(password1) < 6:
             raise forms.ValidationError(
                 _('Password must be at least 6 characters long'),
-                code='to_short')
+                code='to_short'
+            )
 
         return cleaned_data
 

--- a/account/models.py
+++ b/account/models.py
@@ -3,41 +3,60 @@ from django.contrib.auth.models import User
 from django.db.models import signals
 from account.signals import create_profile, delete_profile
 
+
 class UserProfile(models.Model):
-    user = models.OneToOneField(User, editable=False, on_delete=models.CASCADE)
-    uid = models.CharField(verbose_name="User-ID",
-                           max_length=8,
-                           null=True,
-                           default=None)
-    sippin = models.CharField(verbose_name="SIP PIN",
-                              max_length=255,
-                              null=True,
-                              blank=True,
-                              default=None)
-    gastropin = models.CharField(verbose_name="Gastro PIN",
-                                 max_length=255,
-                                 null=True,
-                                 blank=True,
-                                 default=None)
-    rfid = models.CharField(verbose_name="RFID",
-                            max_length=255,
-                            null=True,
-                            blank=True,
-                            default=None)
-    macaddress = models.CharField(verbose_name="MAC-Address",
-                                  max_length=255,
-                                  null=True,
-                                  blank=True,
-                                  default=None)
-    clabpin = models.CharField(verbose_name="c-lab PIN",
-                               max_length=255,
-                               null=True,
-                               blank=True,
-                               default=None)
-    preferred_email = models.CharField(verbose_name="preferred e-mail address",
-                                       max_length=1024,
-                                       null=True,
-                                       default=None)
+    user = models.OneToOneField(
+        User,
+        editable=False,
+        on_delete=models.CASCADE
+    )
+    uid = models.CharField(
+        verbose_name="User-ID",
+        max_length=8,
+        null=True,
+        default=None
+    )
+    sippin = models.CharField(
+        verbose_name="SIP PIN",
+        max_length=255,
+        null=True,
+        blank=True,
+        default=None
+    )
+    gastropin = models.CharField(
+        verbose_name="Gastro PIN",
+        max_length=255,
+        null=True,
+        blank=True,
+        default=None
+    )
+    rfid = models.CharField(
+        verbose_name="RFID",
+        max_length=255,
+        null=True,
+        blank=True,
+        default=None
+    )
+    macaddress = models.CharField(
+        verbose_name="MAC-Address",
+        max_length=255,
+        null=True,
+        blank=True,
+        default=None
+    )
+    clabpin = models.CharField(
+        verbose_name="c-lab PIN",
+        max_length=255,
+        null=True,
+        blank=True,
+        default=None
+    )
+    preferred_email = models.CharField(
+        verbose_name="preferred e-mail address",
+        max_length=1024,
+        null=True,
+        default=None
+    )
     is_member = models.BooleanField(default=False, editable=False)
     is_ldap_admin = models.BooleanField(default=False, editable=False)
     is_circle_member = models.BooleanField(default=False, editable=False)
@@ -48,6 +67,7 @@ class UserProfile(models.Model):
 
     def __unicode__(self):
         return 'Profile: %s' % self.user.username
+
 
 User.profile = property(lambda u: UserProfile.objects.get_or_create(user=u)[0])
 signals.post_save.connect(create_profile, sender=User)

--- a/account/models.py
+++ b/account/models.py
@@ -1,10 +1,21 @@
-from django.db import models
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Django models
+"""
+
 from django.contrib.auth.models import User
+from django.db import models
 from django.db.models import signals
+
 from account.signals import create_profile, delete_profile
 
 
 class UserProfile(models.Model):
+    """
+    UserProfile to be attached to a django User model.
+    """
     user = models.OneToOneField(
         User,
         editable=False,

--- a/account/password_encryption.py
+++ b/account/password_encryption.py
@@ -8,6 +8,7 @@ from Crypto.Cipher import AES
 
 ENCRYPTED_LDAP_PASSWORD = 'encrypted_ldap_password'
 
+
 def encrypt_ldap_password(cleartext_pw):
     """
     Encrypts the cleartext_pw with a randomly generated key.
@@ -28,6 +29,7 @@ def encrypt_ldap_password(cleartext_pw):
     message = iv + aes.encrypt(cleartext_pw)
     return base64.b64encode(message).decode(), base64.b64encode(key).decode()
 
+
 def decrypt_ldap_password(message, key):
     """
     Takes an encrypted, base64 encoded password and the base64 encoded key.
@@ -47,6 +49,7 @@ def decrypt_ldap_password(message, key):
     cleartext_pw = aes.decrypt(ciphertext)
     return cleartext_pw
 
+
 def store_ldap_password(request, password):
     """
     Stores the password in an encrypted session storage and returns the key.
@@ -55,6 +58,7 @@ def store_ldap_password(request, password):
     request.session[ENCRYPTED_LDAP_PASSWORD] = encrypted_pw
     request.session.save()
     return key
+
 
 def get_ldap_password(request):
     cookies = request.COOKIES

--- a/account/signals.py
+++ b/account/signals.py
@@ -4,6 +4,7 @@ def create_profile(sender, instance, signal, created, **kwargs):
     if created:
         UserProfile(user=instance).save()
 
+
 def delete_profile(sender, instance, signal, **kwargs):
     from account.models import UserProfile
     UserProfile(user=instance).delete()

--- a/account/tests.py
+++ b/account/tests.py
@@ -6,7 +6,9 @@ Replace this with more appropriate tests for your application.
 """
 
 from django.test import TestCase
-from password_encryption import encrypt_ldap_password, decrypt_ldap_password
+from account.password_encryption import encrypt_ldap_password, \
+    decrypt_ldap_password
+
 
 class PasswordEncryptionTest(TestCase):
     """
@@ -21,7 +23,6 @@ class PasswordEncryptionTest(TestCase):
         message, key = self.encrypt_it()
         print('key:', key)
         print('message:', message)
-
 
     def test_decrypt_ldap_password(self):
         message, key = self.encrypt_it()


### PR DESCRIPTION
Fixes an IndexError happening when someone deletes an email address  from the forward form and saves the whole thing twice.
This ends up in two problems:
1. the preferredEmail attribute gets deleted from the user's ldap record. Probably this causes the 
    forwarder to ignore the changed attribute (because of its absence) and keeps forwarding email 
    to the previous set email address
2. The user ends up in a 500 Internal Server Error tossed to a blank page.

The last two commits just aim on better source handling (especially with vim on 80x25 consoles)